### PR TITLE
feat: expose all standard BLE scan data (UUIDs, manufacturer, service…

### DIFF
--- a/src/bluetooth_scanner.rs
+++ b/src/bluetooth_scanner.rs
@@ -227,6 +227,23 @@ impl BluetoothScanner {
                             let address = id.to_string();
                             let name = properties.local_name.clone();
                             let rssi = properties.rssi;
+                            
+                            // Convert UUIDs to strings
+                            let services: Vec<String> = properties.services
+                                .iter()
+                                .map(|uuid| uuid.to_string())
+                                .collect();
+                                
+                            // Copy manufacturer data
+                            let manufacturer_data = properties.manufacturer_data.clone();
+
+                            // Convert Service Data (UUID -> Vec<u8>) to (String -> Vec<u8>)
+                            let service_data: std::collections::HashMap<String, Vec<u8>> = properties.service_data
+                                .iter()
+                                .map(|(k, v)| (k.to_string(), v.clone()))
+                                .collect();
+
+                            let tx_power_level = properties.tx_power_level;
 
                             ble_info!(
                                 "Discovered device: {} ({}), RSSI: {:?}",
@@ -235,7 +252,15 @@ impl BluetoothScanner {
                                 rssi
                             );
 
-                            let device_info = DeviceInfo::new(address.clone(), name, rssi);
+                            let device_info = DeviceInfo::new(
+                                address.clone(), 
+                                name, 
+                                rssi,
+                                services,
+                                manufacturer_data,
+                                service_data,
+                                tx_power_level
+                            );
 
                             // Store device
                             if let Ok(mut devices) = self.discovered_devices.lock() {
@@ -265,6 +290,23 @@ impl BluetoothScanner {
                             let name = properties.local_name.clone();
                             let rssi = properties.rssi;
 
+                            // Convert UUIDs to strings
+                            let services: Vec<String> = properties.services
+                                .iter()
+                                .map(|uuid| uuid.to_string())
+                                .collect();
+                                
+                            // Copy manufacturer data
+                            let manufacturer_data = properties.manufacturer_data.clone();
+
+                            // Convert Service Data (UUID -> Vec<u8>) to (String -> Vec<u8>)
+                            let service_data: std::collections::HashMap<String, Vec<u8>> = properties.service_data
+                                .iter()
+                                .map(|(k, v)| (k.to_string(), v.clone()))
+                                .collect();
+
+                            let tx_power_level = properties.tx_power_level;
+
                             ble_debug!(
                                 "Updated device: {} ({}), RSSI: {:?}",
                                 name.as_ref().unwrap_or(&"Unknown".to_string()),
@@ -272,7 +314,15 @@ impl BluetoothScanner {
                                 rssi
                             );
 
-                            let device_info = DeviceInfo::new(address.clone(), name, rssi);
+                            let device_info = DeviceInfo::new(
+                                address.clone(), 
+                                name, 
+                                rssi,
+                                services,
+                                manufacturer_data,
+                                service_data,
+                                tx_power_level
+                            );
 
                             // Update device
                             let should_send = if let Ok(mut devices) = self.discovered_devices.lock() {


### PR DESCRIPTION

## Description

This PR enhances the DeviceInfo structure and the scanning logic to expose the full set of standard advertising data available from `btleplug`.

Previously, only the device name and address were fully exposed (with manufacturer data partially handled). This update ensures that **Service UUIDs**, **Manufacturer Data**, **Service Data**, and **TX Power Level** are all correctly extracted and converted into Godot-compatible types in the `device_discovered` signal.


## Motivation

In some game development contexts (e.g., fitness games connecting to BLE cycling power meters), it is critical to filter the device list by advertised services.

Without this data exposed during the scan results, the player is presented with a cluttered list of every nearby BLE device  instead of just the relevant controllers. 

Exposing the advertised Service UUIDs allows games to instantly filter and display only the relevant peripherals.


## Changes

### 1. src/types.rs
- Updated DeviceInfo struct to include:
    - `services`: `Vec<String>`
    - `manufacturer_data`: `HashMap<u16, Vec<u8>>`
    - `service_data`: `HashMap<String, Vec<u8>>`
    - `tx_power_level`: `Option<i16>`
- Updated `DeviceInfo::to_dictionary()` to convert these into:
    - `services` -> `Array<String>`
    - `manufacturer_data` -> `Dictionary[int, PackedByteArray]`
    - `service_data` -> `Dictionary[String, PackedByteArray]`
    - `tx_power_level` -> `int` (or null)

### 2. src/bluetooth_scanner.rs
- Logic added to extract these fields from the `btleplug` scan properties and pass them to the DeviceInfo constructor.
- Correct retrieval of `service_data` (converting UUID keys to Strings).

## Testing

Verified by building the Windows DLL and macOS dylib via GitHub Actions.
Tested in Godot 4.5 by printing the received dictionary in the `device_discovered` signal