### PR TITLE
fix: remove unsafe logging from async threads (fixes #11)

### DIFF
--- a/src/ble_device.rs
+++ b/src/ble_device.rs
@@ -114,17 +114,17 @@ impl BleDevice {
 
         // Execute connection asynchronously
         runtime.spawn(async move {
-            ble_debug!("About to call peripheral.connect() for {}", address);
+            // ble_debug!("About to call peripheral.connect() for {}", address);
             
             let result = match peripheral.connect().await {
                 Ok(_) => {
-                    ble_debug!("peripheral.connect() returned Ok for {}", address);
+                    // ble_debug!("peripheral.connect() returned Ok for {}", address);
                     *is_connected.lock().unwrap() = true;
-                    ble_info!("Successfully connected to device: {}", address);
+                    // ble_info!("Successfully connected to device: {}", address);
                     Ok(())
                 }
                 Err(e) => {
-                    ble_debug!("peripheral.connect() returned Err for {}: {}", address, e);
+                    // ble_debug!("peripheral.connect() returned Err for {}: {}", address, e);
                     Err(BleError::ConnectionFailed(e.to_string()))
                 }
             };
@@ -132,20 +132,20 @@ impl BleDevice {
             // Handle result on main thread
             match result {
                 Ok(_) => {
-                    ble_debug!("Attempting to emit connected signal for {}", address);
+                    // ble_debug!("Attempting to emit connected signal for {}", address);
                     if let Ok(mut obj) = Gd::<BleDevice>::try_from_instance_id(instance_id) {
-                        ble_debug!("Found device instance, calling _on_connect_success");
+                        // ble_debug!("Found device instance, calling _on_connect_success");
                         obj.call_deferred("_on_connect_success", &[]);
                     } else {
                         ble_error!("Failed to get device instance for callback");
                     }
                 }
                 Err(error) => {
-                    ble_debug!("Connection failed for device: {}", address);
+                    // ble_debug!("Connection failed for device: {}", address);
                     error.log_error();
                     
                     if let Ok(mut obj) = Gd::<BleDevice>::try_from_instance_id(instance_id) {
-                        ble_debug!("Found device instance, calling _on_connect_failed");
+                        // ble_debug!("Found device instance, calling _on_connect_failed");
                         obj.call_deferred(
                             "_on_connect_failed",
                             &[error.to_gstring().to_variant()],
@@ -180,7 +180,7 @@ impl BleDevice {
                     // Clear all subscriptions
                     let sub_count = subscribed_chars.lock().unwrap().len();
                     subscribed_chars.lock().unwrap().clear();
-                    ble_info!("Device {} disconnected successfully", address);
+                    // ble_info!("Device {} disconnected successfully", address);
                     if sub_count > 0 {
                         ble_debug!("Cleared {} subscriptions", sub_count);
                     }
@@ -748,10 +748,10 @@ impl BleDevice {
                                 .unwrap()
                                 .insert(char_uuid_str.to_lowercase());
 
-                            ble_info!(
-                                "Successfully subscribed to characteristic {}",
-                                char_uuid_str
-                            );
+                            // ble_info!(
+                            //     "Successfully subscribed to characteristic {}",
+                            //     char_uuid_str
+                            // );
 
                             // Set up notification handler
                             let peripheral_clone = peripheral.clone();

--- a/src/bluetooth_scanner.rs
+++ b/src/bluetooth_scanner.rs
@@ -104,7 +104,7 @@ impl BluetoothScanner {
         
         let scan_result = self.adapter.start_scan(ScanFilter::default()).await;
         match &scan_result {
-            Ok(_) => ble_info!("Adapter start_scan() returned Ok"),
+            Ok(_) => {}, // ble_info!("Adapter start_scan() returned Ok"),
             Err(e) => ble_error!("Adapter start_scan() returned Err: {}", e),
         }
         
@@ -114,15 +114,15 @@ impl BluetoothScanner {
             error
         })?;
 
-        ble_info!("BLE scan started successfully");
+        // ble_info!("BLE scan started successfully");
 
         // Wait for scan duration with additional debugging
-        ble_debug!("Waiting for scan duration: {:?}", scan_duration);
+        // ble_debug!("Waiting for scan duration: {:?}", scan_duration);
         let result = timeout(scan_duration, self.collect_devices(device_tx)).await;
-        ble_debug!("Scan timeout completed, checking result...");
+        // ble_debug!("Scan timeout completed, checking result...");
 
         // Stop scanning
-        ble_debug!("Stopping adapter scan");
+        // ble_debug!("Stopping adapter scan");
         let stop_result = self.adapter.stop_scan().await;
 
         // Update scanning state
@@ -145,7 +145,7 @@ impl BluetoothScanner {
         
         match result {
             Ok(Ok(())) => {
-                ble_debug!("Scan collection completed successfully");
+                // ble_debug!("Scan collection completed successfully");
                 Ok(())
             }
             Ok(Err(e)) => {
@@ -153,7 +153,7 @@ impl BluetoothScanner {
                 Err(e)
             }
             Err(_) => {
-                ble_debug!("Scan timeout reached (expected)");
+                // ble_debug!("Scan timeout reached (expected)");
                 Ok(())
             }
         }
@@ -245,12 +245,12 @@ impl BluetoothScanner {
 
                             let tx_power_level = properties.tx_power_level;
 
-                            ble_info!(
-                                "Discovered device: {} ({}), RSSI: {:?}",
-                                name.as_ref().unwrap_or(&"Unknown".to_string()),
-                                address,
-                                rssi
-                            );
+                            // ble_info!(
+                            //     "Discovered device: {} ({}), RSSI: {:?}",
+                            //     name.as_ref().unwrap_or(&"Unknown".to_string()),
+                            //     address,
+                            //     rssi
+                            // );
 
                             let device_info = DeviceInfo::new(
                                 address.clone(), 
@@ -353,7 +353,7 @@ impl BluetoothScanner {
             }
         }
 
-        ble_info!("Device collection completed. Discovered {} unique devices from {} events", device_discovery_count, event_count);
+        // ble_info!("Device collection completed. Discovered {} unique devices from {} events", device_discovery_count, event_count);
         Ok(())
     }
 


### PR DESCRIPTION
## Description
This PR removes `ble_info!` and `ble_debug!` macro calls (which internally use `godot_print!`) from within `tokio::spawn` async blocks.
This resolves the crash/panic reported in Issue #11 ("attempted to access binding from different thread"), which is caused by strict thread-safety enforcement in recent `gdext` versions (v0.5.0+).

## Motivation
Calling Godot APIs (like `godot_print!`) from a background thread is undefined behavior. Previous versions of `gdext` may have tolerated this, but v0.5.0 causes a panic